### PR TITLE
readmeのlintと@memberをgithubのOverviewへのリンクにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 ## member
 
-@honahuku  
-@SoragamiRaito  
-@Ringo-onct  
-@gumi-69  
+[@honahuku](https://github.com/honahuku)  
+[@SoragamiRaito](https://github.com/SoragamiRaito)  
+[@Ringo-onct](https://github.com/Ringo-onct)  
+[@gumi-69](https://github.com/gumi-69)  
 
 ## rule
+
 ### commit & branch
+
 コミットメッセージとブランチの命名規則は[Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/)に準拠するものとします。  
 例としては以下のとおりです。  
+
 ```text
 feat: hoge関数の追加
 feat: poyoの導入
@@ -18,7 +21,8 @@ fix: typo
 ```
 
 ### merge & review
-mainへの直接コミットはせず、Pull Request(PR) を作成し1名以上のレビューをもらってください。 
+
+mainへの直接コミットはせず、Pull Request(PR) を作成し1名以上のレビューをもらってください。
 
 ## kind
 


### PR DESCRIPTION
markdown lint を使っているのでそのルール通りのlintになっています。
webで見るときにリンクのほうがいいかな？みたいな。